### PR TITLE
feat: add routing & scoring to lead detail (#103)

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -844,3 +844,126 @@
         transform: translateY(0);
     }
 }
+
+/* Tier badges
+   ========================================================================== */
+
+.tier-badge {
+    font-size: 0.7rem;
+    font-weight: 700;
+    padding: 0.15rem 0.45rem;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+}
+
+.tier-T1 { background: #dc262620; color: #dc2626; }
+.tier-T2 { background: #d9770620; color: #d97706; }
+.tier-T3 { background: #6b728020; color: #6b7280; }
+.tier-T4 { background: #6b728015; color: #9ca3af; }
+.tier-T5 { background: #6b728010; color: #d1d5db; }
+
+/* Progress bar (routing confidence on detail page)
+   ========================================================================== */
+
+.progress-bar-track {
+    width: 100%;
+    max-width: 200px;
+    height: 8px;
+    background: var(--dash-border);
+    border-radius: 4px;
+    overflow: hidden;
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: 0.5rem;
+}
+
+.progress-bar-fill {
+    height: 100%;
+    border-radius: 4px;
+    background: var(--dash-primary);
+    transition: width 0.3s ease;
+}
+
+/* Routing & Scoring section (detail page)
+   ========================================================================== */
+
+.routing-scoring-section {
+    background: var(--dash-surface);
+    border: 1px solid var(--dash-border);
+    border-radius: var(--dash-radius);
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+.routing-scoring-section h3 {
+    margin: 0 0 1rem 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--dash-text);
+}
+
+.routing-scoring-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+.routing-scoring-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.routing-scoring-field .field-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--dash-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.routing-scoring-field .field-value {
+    font-size: 0.85rem;
+    color: var(--dash-text);
+}
+
+.routing-scoring-field.full-width {
+    grid-column: 1 / -1;
+}
+
+/* Urgency color coding */
+
+.urgency-text-low { color: var(--dash-text-muted); }
+.urgency-text-medium { color: #d97706; }
+.urgency-text-high { color: #dc2626; }
+.urgency-text-critical { color: #dc2626; font-weight: 700; }
+
+/* Expandable text block (specialist context) */
+
+.expandable-text {
+    position: relative;
+}
+
+.expandable-text-content {
+    max-height: 3rem;
+    overflow: hidden;
+    font-size: 0.8rem;
+    color: var(--dash-text);
+    line-height: 1.5;
+    transition: max-height 0.3s ease;
+}
+
+.expandable-text-content.expanded {
+    max-height: none;
+}
+
+.expandable-toggle {
+    font-size: 0.75rem;
+    color: var(--dash-primary);
+    cursor: pointer;
+    border: none;
+    background: none;
+    padding: 0.25rem 0;
+}

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -69,6 +69,27 @@
         return brands.find(function (b) { return b.id == brandId; });
     }
 
+    function tierLabel(tier) {
+        if (!tier) return null;
+        var labels = { T1: 'T1 — Hot', T2: 'T2 — Warm', T3: 'T3 — Cold', T4: 'T4', T5: 'T5' };
+        return labels[tier] || tier;
+    }
+
+    function formatRelativeTime(dateStr) {
+        if (!dateStr) return '';
+        var now = new Date();
+        var then = new Date(dateStr);
+        var diffMs = now - then;
+        var diffMins = Math.floor(diffMs / 60000);
+        if (diffMins < 1) return 'just now';
+        if (diffMins < 60) return diffMins + 'm ago';
+        var diffHrs = Math.floor(diffMins / 60);
+        if (diffHrs < 24) return diffHrs + 'h ago';
+        var diffDays = Math.floor(diffHrs / 24);
+        if (diffDays < 30) return diffDays + 'd ago';
+        return formatDate(dateStr);
+    }
+
     function showToast(message, type) {
         type = type || 'info';
         var container = document.querySelector('.toast-container');
@@ -429,6 +450,7 @@
             populateDetailFields(lead);
             renderStageActions(lead);
             renderQualification(lead);
+            renderRoutingScoring(lead);
         } catch (err) {
             showToast('Failed to load lead: ' + err.message, 'error');
         }
@@ -465,6 +487,12 @@
         setFieldValue('edit-value', lead.value);
         setFieldValue('edit-closing-date', lead.closing_date ? lead.closing_date.substring(0, 10) : '');
         setFieldValue('edit-description', lead.description);
+        setFieldValue('edit-tier', lead.tier);
+        setFieldValue('edit-organization-type', lead.organization_type);
+        setFieldValue('edit-lead-source', lead.lead_source);
+        setFieldValue('edit-budget-range', lead.budget_range);
+        setFieldValue('edit-urgency', lead.urgency);
+        setFieldValue('edit-funding-status', lead.funding_status);
     }
 
     function setFieldValue(id, value) {
@@ -516,6 +544,111 @@
         var reasoningEl = document.getElementById('qual-reasoning');
         if (reasoningEl) {
             reasoningEl.textContent = lead.qualify_reasoning || '';
+        }
+    }
+
+    function renderRoutingScoring(lead) {
+        var section = document.getElementById('routing-scoring-section');
+        if (!section) return;
+
+        var hasData = lead.tier || lead.routing_confidence != null || lead.organization_type ||
+            lead.lead_source || lead.budget_range || lead.urgency || lead.funding_status ||
+            lead.last_scored_at || lead.specialist_context;
+
+        if (!hasData) {
+            section.style.display = 'none';
+            return;
+        }
+
+        section.style.display = '';
+        var grid = document.getElementById('routing-scoring-grid');
+        grid.textContent = '';
+
+        if (lead.tier) {
+            grid.appendChild(el('div', { className: 'routing-scoring-field' }, [
+                el('span', { className: 'field-label', textContent: 'Tier' }),
+                el('span', {
+                    className: 'tier-badge tier-' + lead.tier,
+                    style: 'font-size:1rem;padding:0.25rem 0.6rem;',
+                    textContent: tierLabel(lead.tier),
+                }),
+            ]));
+        }
+
+        if (lead.routing_confidence != null) {
+            var progressBar = el('div', { className: 'progress-bar-track' }, [
+                el('div', {
+                    className: 'progress-bar-fill',
+                    style: 'width:' + lead.routing_confidence + '%',
+                }),
+            ]);
+            grid.appendChild(el('div', { className: 'routing-scoring-field' }, [
+                el('span', { className: 'field-label', textContent: 'Routing Confidence' }),
+                el('div', { className: 'field-value' }, [progressBar, ' ' + lead.routing_confidence + '%']),
+            ]));
+        }
+
+        if (lead.organization_type) {
+            grid.appendChild(el('div', { className: 'routing-scoring-field' }, [
+                el('span', { className: 'field-label', textContent: 'Organization Type' }),
+                el('span', { className: 'field-value', textContent: lead.organization_type }),
+            ]));
+        }
+
+        if (lead.lead_source) {
+            grid.appendChild(el('div', { className: 'routing-scoring-field' }, [
+                el('span', { className: 'field-label', textContent: 'Lead Source' }),
+                el('span', { className: 'field-value', textContent: lead.lead_source }),
+            ]));
+        }
+
+        if (lead.budget_range) {
+            grid.appendChild(el('div', { className: 'routing-scoring-field' }, [
+                el('span', { className: 'field-label', textContent: 'Budget Range' }),
+                el('span', { className: 'field-value', textContent: lead.budget_range.replace(/_/g, ' ') }),
+            ]));
+        }
+
+        if (lead.urgency) {
+            grid.appendChild(el('div', { className: 'routing-scoring-field' }, [
+                el('span', { className: 'field-label', textContent: 'Urgency' }),
+                el('span', {
+                    className: 'field-value urgency-text-' + lead.urgency,
+                    textContent: lead.urgency,
+                }),
+            ]));
+        }
+
+        if (lead.funding_status) {
+            grid.appendChild(el('div', { className: 'routing-scoring-field' }, [
+                el('span', { className: 'field-label', textContent: 'Funding Status' }),
+                el('span', { className: 'field-value', textContent: lead.funding_status }),
+            ]));
+        }
+
+        if (lead.last_scored_at) {
+            grid.appendChild(el('div', { className: 'routing-scoring-field' }, [
+                el('span', { className: 'field-label', textContent: 'Last Scored' }),
+                el('span', { className: 'field-value', textContent: formatRelativeTime(lead.last_scored_at) }),
+            ]));
+        }
+
+        if (lead.specialist_context) {
+            var contextText = typeof lead.specialist_context === 'string'
+                ? lead.specialist_context
+                : JSON.stringify(lead.specialist_context, null, 2);
+
+            var contentDiv = el('div', { className: 'expandable-text-content', textContent: contextText });
+            var toggleBtn = el('button', { className: 'expandable-toggle', textContent: 'Show more' });
+            toggleBtn.addEventListener('click', function () {
+                var isExpanded = contentDiv.classList.toggle('expanded');
+                toggleBtn.textContent = isExpanded ? 'Show less' : 'Show more';
+            });
+
+            grid.appendChild(el('div', { className: 'routing-scoring-field full-width' }, [
+                el('span', { className: 'field-label', textContent: 'Specialist Context' }),
+                el('div', { className: 'expandable-text' }, [contentDiv, toggleBtn]),
+            ]));
         }
     }
 

--- a/templates/admin/lead-detail.html.twig
+++ b/templates/admin/lead-detail.html.twig
@@ -41,6 +41,14 @@
                 <div class="qual-reasoning" id="qual-reasoning"></div>
             </div>
 
+            <!-- Routing & Scoring -->
+            <div class="routing-scoring-section" id="routing-scoring-section" style="display:none;">
+                <h3>Routing &amp; Scoring</h3>
+                <div class="routing-scoring-grid" id="routing-scoring-grid">
+                    <!-- Populated by JS -->
+                </div>
+            </div>
+
             <!-- Editable fields -->
             <form id="lead-edit-form" class="detail-form">
                 <div class="form-row">
@@ -96,6 +104,80 @@
                 <div class="form-group">
                     <label for="edit-description">Description</label>
                     <textarea id="edit-description" name="description" rows="4"></textarea>
+                </div>
+                <h4 style="margin:1.5rem 0 0.75rem;font-size:0.85rem;color:var(--dash-text-muted);text-transform:uppercase;letter-spacing:0.03em;">Routing &amp; Scoring Overrides</h4>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="edit-tier">Tier</label>
+                        <select id="edit-tier" name="tier">
+                            <option value="">—</option>
+                            <option value="T1">T1 — Hot</option>
+                            <option value="T2">T2 — Warm</option>
+                            <option value="T3">T3 — Cold</option>
+                            <option value="T4">T4</option>
+                            <option value="T5">T5</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="edit-organization-type">Organization Type</label>
+                        <select id="edit-organization-type" name="organization_type">
+                            <option value="">—</option>
+                            <option value="startup">Startup</option>
+                            <option value="nonprofit">Nonprofit</option>
+                            <option value="charity">Charity</option>
+                            <option value="indigenous">Indigenous</option>
+                            <option value="community">Community</option>
+                            <option value="government">Government</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="edit-lead-source">Lead Source</label>
+                        <select id="edit-lead-source" name="lead_source">
+                            <option value="">—</option>
+                            <option value="rfp">RFP</option>
+                            <option value="signal">Signal</option>
+                            <option value="job_posting">Job Posting</option>
+                            <option value="funding">Funding</option>
+                            <option value="website_audit">Website Audit</option>
+                            <option value="manual">Manual</option>
+                            <option value="directory">Directory</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="edit-budget-range">Budget Range</label>
+                        <select id="edit-budget-range" name="budget_range">
+                            <option value="">—</option>
+                            <option value="under_2k">Under $2K</option>
+                            <option value="2k_5k">$2K – $5K</option>
+                            <option value="5k_10k">$5K – $10K</option>
+                            <option value="10k_25k">$10K – $25K</option>
+                            <option value="25k_plus">$25K+</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="edit-urgency">Urgency</label>
+                        <select id="edit-urgency" name="urgency">
+                            <option value="">—</option>
+                            <option value="low">Low</option>
+                            <option value="medium">Medium</option>
+                            <option value="high">High</option>
+                            <option value="critical">Critical</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="edit-funding-status">Funding Status</label>
+                        <select id="edit-funding-status" name="funding_status">
+                            <option value="">—</option>
+                            <option value="none">None</option>
+                            <option value="applied">Applied</option>
+                            <option value="received">Received</option>
+                            <option value="unknown">Unknown</option>
+                        </select>
+                    </div>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- Add read-only Routing & Scoring display section between qualification panel and edit form on lead detail page, showing tier badge, routing confidence progress bar, organization type, lead source, budget range, urgency, funding status, last scored timestamp, and expandable specialist context
- Add 6 editable override select fields (tier, organization type, lead source, budget range, urgency, funding status) to the edit form, auto-included in PATCH via existing FormData flow
- Add supporting CSS: tier badges, progress bar, routing-scoring grid, urgency color coding, expandable text block

## Test plan
- [ ] Navigate to `/admin/leads/{id}` for a lead with routing/scoring data -- verify the Routing & Scoring section appears with correct field values
- [ ] Verify section is hidden when lead has no routing/scoring data
- [ ] Change override fields (tier, urgency, etc.) and click Save -- verify values persist on reload
- [ ] Verify specialist context expand/collapse toggle works

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)