### PR TITLE
feat: display new Lead fields on kanban cards and lead list

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -844,3 +844,64 @@
         transform: translateY(0);
     }
 }
+
+/* Tier badges
+   ========================================================================== */
+
+.tier-badge {
+    font-size: 0.7rem;
+    font-weight: 700;
+    padding: 0.15rem 0.45rem;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+}
+
+.tier-T1 {
+    background: #dc262620;
+    color: #dc2626;
+}
+
+.tier-T2 {
+    background: #d9770620;
+    color: #d97706;
+}
+
+.tier-T3 {
+    background: #6b728020;
+    color: #6b7280;
+}
+
+.tier-T4 {
+    background: #6b728015;
+    color: #9ca3af;
+}
+
+.tier-T5 {
+    background: #6b728010;
+    color: #d1d5db;
+}
+
+.routing-confidence {
+    font-size: 0.7rem;
+    color: var(--dash-text-muted);
+    white-space: nowrap;
+}
+
+.org-type-tag {
+    font-size: 0.7rem;
+    color: var(--dash-text-muted);
+    background: var(--dash-bg);
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+}
+
+.lead-source-tag {
+    font-size: 0.7rem;
+    color: var(--dash-text-muted);
+    background: var(--dash-bg);
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    text-transform: lowercase;
+}

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -241,21 +241,28 @@
         var scoreClass = score >= 70 ? 'score-high' : score >= 40 ? 'score-mid' : 'score-low';
         var urgency = getUrgency(lead.closing_date);
 
-        // Card header
+        // Card header: label + tier badge (or score badge if no tier)
         var headerChildren = [el('span', { className: 'card-label', textContent: lead.label || '' })];
-        if (score != null) {
+        if (lead.tier) {
+            headerChildren.push(el('span', {
+                className: 'tier-badge tier-' + lead.tier,
+                textContent: lead.tier,
+            }));
+        } else if (score != null) {
             headerChildren.push(el('span', { className: 'score-badge ' + scoreClass, textContent: String(score) }));
         }
         var cardHeader = el('div', { className: 'card-header' }, headerChildren);
 
-        // Card body parts
         var parts = [cardHeader];
 
         if (lead.company_name) {
             parts.push(el('div', { className: 'card-company', textContent: lead.company_name }));
         }
 
-        // Meta row
+        if (lead.organization_type) {
+            parts.push(el('span', { className: 'org-type-tag', textContent: lead.organization_type }));
+        }
+
         var metaChildren = [];
         if (brand) {
             metaChildren.push(el('span', {
@@ -264,8 +271,13 @@
                 textContent: brand.name,
             }));
         }
-        if (lead.source) {
+        if (lead.lead_source) {
+            metaChildren.push(el('span', { className: 'lead-source-tag', textContent: lead.lead_source }));
+        } else if (lead.source) {
             metaChildren.push(el('span', { className: 'source-tag', textContent: lead.source }));
+        }
+        if (lead.routing_confidence != null) {
+            metaChildren.push(el('span', { className: 'routing-confidence', textContent: lead.routing_confidence + '%' }));
         }
         if (urgency) {
             metaChildren.push(el('span', { className: 'urgency-badge urgency-' + urgency.level, textContent: urgency.label }));
@@ -316,7 +328,7 @@
 
         if (filtered.length === 0) {
             var emptyRow = el('tr', {}, [el('td', { className: 'empty-state' }, ['No leads found'])]);
-            emptyRow.querySelector('td').setAttribute('colspan', '9');
+            emptyRow.querySelector('td').setAttribute('colspan', '13');
             tbody.appendChild(emptyRow);
             return;
         }
@@ -353,6 +365,28 @@
                 scoreCell.appendChild(el('span', { className: 'score-badge ' + scoreClass, textContent: String(score) }));
             }
             cells.push(scoreCell);
+            // Tier
+            var tierCell = el('td');
+            if (l.tier) {
+                tierCell.appendChild(el('span', { className: 'tier-badge tier-' + l.tier, textContent: l.tier }));
+            }
+            cells.push(tierCell);
+            // Routing
+            var routingCell = el('td');
+            if (l.routing_confidence != null) {
+                var routingText = l.routing_confidence + '%';
+                if (brand) routingText += ' · ' + brand.name;
+                routingCell.appendChild(el('span', { className: 'routing-confidence', textContent: routingText }));
+            }
+            cells.push(routingCell);
+            // Org Type
+            cells.push(el('td', { textContent: l.organization_type || '' }));
+            // Lead Source
+            var sourceCell2 = el('td');
+            if (l.lead_source) {
+                sourceCell2.appendChild(el('span', { className: 'lead-source-tag', textContent: l.lead_source }));
+            }
+            cells.push(sourceCell2);
             // Value
             cells.push(el('td', { textContent: l.value ? '$' + Number(l.value).toLocaleString() : '' }));
             // Closing

--- a/templates/admin/lead-list.html.twig
+++ b/templates/admin/lead-list.html.twig
@@ -28,6 +28,10 @@
                     <th class="sortable" data-sort="brand_id">Brand</th>
                     <th class="sortable" data-sort="source">Source</th>
                     <th class="sortable" data-sort="qualify_rating">Score</th>
+                    <th class="sortable" data-sort="tier">Tier</th>
+                    <th class="sortable" data-sort="routing_confidence">Routing</th>
+                    <th class="sortable" data-sort="organization_type">Org Type</th>
+                    <th class="sortable" data-sort="lead_source">Lead Source</th>
                     <th class="sortable" data-sort="value">Value</th>
                     <th class="sortable" data-sort="closing_date">Closing</th>
                     <th class="sortable" data-sort="updated_at">Updated</th>


### PR DESCRIPTION
## Summary
- Display tier, routing_confidence, organization_type, and lead_source on admin dashboard kanban cards and lead list table
- Kanban cards show tier badge (replacing score badge when tier is present), org type tag, lead source tag, and routing confidence percentage
- Lead list table adds 4 new sortable columns: Tier, Routing, Org Type, Lead Source
- CSS styles for tier badges (T1-T5 with color-coded backgrounds), routing confidence, org-type-tag, and lead-source-tag

Closes #102

## Test plan
- [ ] Verify kanban cards display tier badge for leads with a tier value
- [ ] Verify kanban cards fall back to score badge when no tier is set
- [ ] Verify organization_type and lead_source appear on cards
- [ ] Verify routing_confidence percentage displays on cards
- [ ] Verify lead list table has 4 new sortable columns
- [ ] Verify sorting works on new columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)